### PR TITLE
Circular reference FIXED!

### DIFF
--- a/InventoryDAL/Database/MySqlContext.cs
+++ b/InventoryDAL/Database/MySqlContext.cs
@@ -11,64 +11,52 @@ namespace InventoryDAL.Database
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             // use docker composer mysql credentials (safe to store in code)
-            optionsBuilder.UseMySQL(
-                "server=db;port=3306;userid=dbuser;password=dbuserpassword;database=accountowner;");
+            optionsBuilder
+                //.UseLazyLoadingProxies()
+                .UseMySQL("server=db;port=3306;userid=dbuser;password=dbuserpassword;database=accountowner;");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
 
-            modelBuilder.Entity<ProductEntity>(entity =>
+            modelBuilder.Entity<ProductEntity>(productEntity =>
             {
-                entity.HasKey(p => p.Id);
-                entity.Property(p => p.Name).IsRequired();
-                entity.Property(p => p.Sku).IsRequired();
-                entity.HasMany(e => e.StockEntities)
+                productEntity.HasKey(p => p.Id);
+                productEntity.Property(p => p.Name).IsRequired();
+                productEntity.Property(p => p.Sku).IsRequired();
+                productEntity.HasMany(e => e.StockEntities)
                       .WithOne(s => s.ProductEntity)
                       .HasForeignKey(s => s.ProductId);
+                productEntity.HasMany(e => e.ProductTagEntities)
+                     .WithOne(p => p.ProductEntity)
+                     .HasForeignKey(p => p.ProductId);
             });
 
-            modelBuilder.Entity<StockEntity>(entity =>
+            modelBuilder.Entity<StockEntity>(stockEntity =>
             {
-                entity.HasKey(s => s.Id);
-                entity.Property(s => s.Amount).IsRequired();
-                entity.Property(s => s.Date).IsRequired();
-                //entity.HasOne(s => s.Product)
-                //      .WithMany()
-                //      .HasForeignKey(p => p.ProductId);
+                stockEntity.HasKey(s => s.Id);
+                stockEntity.Property(s => s.Amount).IsRequired();
+                stockEntity.Property(s => s.Date).IsRequired();
             });
 
-            modelBuilder.Entity<TagEntity>(entity =>
+            modelBuilder.Entity<TagEntity>(tagEntity =>
             {
-                entity.HasKey(t => t.Id);
-                entity.Property(t => t.Name).IsRequired();
-                entity.HasIndex(t => t.Name).IsUnique();
+                tagEntity.HasKey(t => t.Id);
+                tagEntity.Property(t => t.Name).IsRequired();
+                //entity.HasIndex(t => t.Name).IsUnique();
             });
 
-            //modelBuilder.Entity<ProductTagEntity>(entity =>
-            //{
-            //    entity.HasKey(j => new { j.ProductId, j.TagId });
-            //    entity.HasOne(j => j.ProductEntity)
-            //          .WithMany(p => p.ProductTagEntities)
-            //          .HasForeignKey(j => j.ProductId);
-            //    entity.HasOne(j => j.TagEntity)
-            //          .WithMany(t => t.ProductTagEntities)
-            //          .HasForeignKey(j => j.TagId);
-            //});
-
-            modelBuilder.Entity<ProductTagEntity>()
-                .HasKey(t => new { t.ProductId, t.TagId });
-
-            modelBuilder.Entity<ProductTagEntity>()
-                .HasOne(pt => pt.ProductEntity)
-                .WithMany(p => p.ProductTagEntities)
-                .HasForeignKey(pt => pt.ProductId);
-
-            modelBuilder.Entity<ProductTagEntity>()
-                .HasOne(pt => pt.TagEntity)
-                .WithMany(t => t.ProductTagEntities)
-                .HasForeignKey(pt => pt.TagId);
+            modelBuilder.Entity<ProductTagEntity>(productTag =>
+            {
+                productTag.HasKey(t => new { t.ProductId, t.TagId });
+                productTag.HasOne(pt => pt.ProductEntity)
+                          .WithMany(p => p.ProductTagEntities)
+                          .HasForeignKey(pt => pt.ProductId);
+                productTag.HasOne(pt => pt.TagEntity)
+                          .WithMany(t => t.ProductTagEntities)
+                          .HasForeignKey(pt => pt.TagId);
+            });
         }
     }
 }

--- a/InventoryDAL/Database/MySqlContext.cs
+++ b/InventoryDAL/Database/MySqlContext.cs
@@ -7,7 +7,7 @@ using InventoryDAL.Stocks;
 namespace InventoryDAL.Database
 {
     public class MySqlContext : DbContext
-    {
+    {       
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             // use docker composer mysql credentials (safe to store in code)
@@ -31,6 +31,7 @@ namespace InventoryDAL.Database
                 productEntity.HasMany(e => e.ProductTagEntities)
                      .WithOne(p => p.ProductEntity)
                      .HasForeignKey(p => p.ProductId);
+                productEntity.HasData(new ProductEntity() { Id = 1, Name = "testProduct1", Price = 5, Sku = "Sku1" });
             });
 
             modelBuilder.Entity<StockEntity>(stockEntity =>
@@ -38,13 +39,15 @@ namespace InventoryDAL.Database
                 stockEntity.HasKey(s => s.Id);
                 stockEntity.Property(s => s.Amount).IsRequired();
                 stockEntity.Property(s => s.Date).IsRequired();
+                stockEntity.HasData(new StockEntity() { Id = 1, ProductId = 1, Amount = 5 });
             });
 
             modelBuilder.Entity<TagEntity>(tagEntity =>
             {
                 tagEntity.HasKey(t => t.Id);
                 tagEntity.Property(t => t.Name).IsRequired();
-                //entity.HasIndex(t => t.Name).IsUnique();
+                //tagEntity.HasIndex(t => t.Name).IsUnique();
+                tagEntity.HasData(new TagEntity() { Id = 1, Name = "testTag1" });
             });
 
             modelBuilder.Entity<ProductTagEntity>(productTag =>

--- a/InventoryDAL/Database/MySqlDAO.cs
+++ b/InventoryDAL/Database/MySqlDAO.cs
@@ -24,10 +24,10 @@ namespace InventoryDAL.Database
             return e;
         }
 
-        public List<EntityType> GetAll()
+        public virtual List<EntityType> GetAll()
         {
             this.dbContext.Database.EnsureCreated();
-            Task<List<EntityType>> lst = this.Table.ToListAsync(); // TODO: No Tags in Product?? Swagger sometimes gives a failed to fetch.
+            Task<List<EntityType>> lst = this.Table.ToListAsync();
             lst.Wait(); 
             return lst.Result;
         }

--- a/InventoryDAL/Products/Builders/IProductBuilder.cs
+++ b/InventoryDAL/Products/Builders/IProductBuilder.cs
@@ -4,6 +4,6 @@ namespace InventoryDAL.Products
 {
     public interface IProductBuilder : IProduct
     {
-        Product Build();
+        Product GetResult();
     }
 }

--- a/InventoryDAL/Products/Builders/IProductEntityBuilder.cs
+++ b/InventoryDAL/Products/Builders/IProductEntityBuilder.cs
@@ -6,6 +6,6 @@ namespace InventoryDAL.Products
 {
     public interface IProductEntityBuilder : IProductEntity
     {
-        ProductEntity Build();
+        ProductEntity GetResult();
     }
 }

--- a/InventoryDAL/Products/Builders/ProductBuilder.cs
+++ b/InventoryDAL/Products/Builders/ProductBuilder.cs
@@ -22,6 +22,8 @@ namespace InventoryDAL.Products
         public string Sku { get; set; }
         public List<Tag> Tags { get; set; }
         public List<Stock> Stocks { get; set; }
+        private readonly ProductEntity productEntity;
+
 
         public ProductBuilder(ProductEntity productEntity,
                               IDomainFactory domainFactory,
@@ -29,25 +31,26 @@ namespace InventoryDAL.Products
         {
             this.domainFactory = domainFactory;
             this.repositoryFactory = repositoryFactory;
-            
+            this.productEntity = productEntity;
+
+
             this.Id = productEntity.Id;
             this.Name = productEntity.Name;
             this.Price = productEntity.Price;
             this.Sku = productEntity.Sku;
-            this.Tags = GetTags(productEntity.ProductTagEntities);
-            this.Stocks = GetStocks(productEntity.StockEntities);
         }
 
-        private List<Tag> GetTags(List<ProductTagEntity> productTagEntities)
+        public void BuildTags()
         {
-            if (productTagEntities == null) return new List<Tag>();
+            List<ProductTagEntity> productTagEntities = productEntity.ProductTagEntities;
+            if (productTagEntities == null) return;
             List<Tag> tags = new List<Tag>();
             productTagEntities.ForEach(prodTag =>
             {
                 Tag tag = GetTag(prodTag);
                 tags.Add(tag);
             });
-            return tags;
+            this.Tags = tags;
         }
 
         private Tag GetTag(ProductTagEntity prodTag)
@@ -57,16 +60,17 @@ namespace InventoryDAL.Products
             return tag;
         }
 
-        private List<Stock> GetStocks(List<StockEntity> stockEntities)
+        public void BuildStocks()
         {
-            if (stockEntities == null) return new List<Stock>();
+            List<StockEntity> stockEntities = productEntity.StockEntities;
+            if (stockEntities == null) return;
             List<Stock> stocks = new List<Stock>();
             stockEntities.ForEach(stockEntity =>
             {
                 Stock stock = GetStock(stockEntity);
                 stocks.Add(stock);
             });
-            return stocks;
+            this.Stocks = stocks;
         }
 
         private Stock GetStock(StockEntity stockEntity)
@@ -76,7 +80,7 @@ namespace InventoryDAL.Products
             return stock;
         }
 
-        public Product Build()
+        public Product GetResult()
         {
             Product product = domainFactory.CreateProduct();
             product.Id = this.Id;

--- a/InventoryDAL/Products/Builders/ProductBuilder.cs
+++ b/InventoryDAL/Products/Builders/ProductBuilder.cs
@@ -38,6 +38,8 @@ namespace InventoryDAL.Products
             this.Name = productEntity.Name;
             this.Price = productEntity.Price;
             this.Sku = productEntity.Sku;
+            this.Tags = new List<Tag>();
+            this.Stocks = new List<Stock>();
         }
 
         public void BuildTags()

--- a/InventoryDAL/Products/Builders/ProductEntityBuilder.cs
+++ b/InventoryDAL/Products/Builders/ProductEntityBuilder.cs
@@ -21,6 +21,8 @@ namespace InventoryDAL.Products
         public string Sku { get; set; }
         public List<ProductTagEntity> ProductTagEntities { get; set; }
         public List<StockEntity> StockEntities { get; set; }
+        private readonly Product product;
+
 
         public ProductEntityBuilder(Product product,
                                     IEntityFactory entityFactory,
@@ -28,44 +30,46 @@ namespace InventoryDAL.Products
         {
             this.entityFactory = entityFactory;
             this.daoFactory = daoFactory;
+            this.product = product;
 
             this.Id = product.Id;
             this.Name = product.Name;
             this.Price = product.Price;
             this.Sku = product.Sku;
-            this.ProductTagEntities = GetProductTagEntities(product.Id, product.Tags);
-            this.StockEntities = GetStockEntities(product.Stocks);
+
         }
 
-        private List<ProductTagEntity> GetProductTagEntities(int productId, List<Tag> tags)
+        public void BuildProductTagEntities()
         {
-            if (tags == null || tags.Count == 0) return new List<ProductTagEntity>();
+            List<Tag> tags = product.Tags;
+            if (tags == null || tags.Count == 0) return;
             List<ProductTagEntity> newProductTagEntities = new List<ProductTagEntity>();
             tags.ForEach(tag =>
             {
-                ProductTagEntity ptEntity = GetProductTagEntity(productId, tag.Id);
+                ProductTagEntity ptEntity = GetProductTagEntity(product.Id, tag.Id);
                 newProductTagEntities.Add(ptEntity);
             });
-            return newProductTagEntities;
+            this.ProductTagEntities = newProductTagEntities;
         }
 
         private ProductTagEntity GetProductTagEntity(int productId, int tagId)
         {
             ProductTagEntity ptEntity = daoFactory.ProductTagDAO.Get(productId, tagId);
-            if (ptEntity == null) ptEntity = entityFactory.CreateProductTagEntity(productId, tagId, this.daoFactory); 
+            if (ptEntity == null) ptEntity = entityFactory.CreateProductTagEntity(productId, tagId, this.daoFactory);
             return ptEntity;
         }
 
-        private List<StockEntity> GetStockEntities(List<Stock> stocks)
+        public void BuildStockEntities()
         {
-            if (stocks == null || stocks.Count == 0) return new List<StockEntity>();
+            List<Stock> stocks = product.Stocks;
+            if (stocks == null || stocks.Count == 0) return;
             var stockEntities = new List<StockEntity>();
             stocks.ForEach(stock =>
             {
-                StockEntity stockEntity = GetStockEntity(stock.Id); 
+                StockEntity stockEntity = GetStockEntity(stock.Id);
                 stockEntities.Add(stockEntity);
             });
-            return stockEntities;
+            this.StockEntities = stockEntities;
         }
 
         private StockEntity GetStockEntity(int stockId)
@@ -75,10 +79,10 @@ namespace InventoryDAL.Products
             return stockEntity;
         }
 
-        public ProductEntity Build()
+        public ProductEntity GetResult()
         {
-            ProductEntity productEntity = daoFactory.ProductEntityDAO.Get(this.Id); 
-            if (productEntity == null) productEntity = entityFactory.CreateProductEntity(); 
+            ProductEntity productEntity = daoFactory.ProductEntityDAO.Get(this.Id);
+            if (productEntity == null) productEntity = entityFactory.CreateProductEntity();
             productEntity.Name = this.Name;
             productEntity.Price = this.Price;
             productEntity.Sku = this.Sku;

--- a/InventoryDAL/Products/Builders/ProductEntityBuilder.cs
+++ b/InventoryDAL/Products/Builders/ProductEntityBuilder.cs
@@ -36,6 +36,8 @@ namespace InventoryDAL.Products
             this.Name = product.Name;
             this.Price = product.Price;
             this.Sku = product.Sku;
+            this.ProductTagEntities = new List<ProductTagEntity>();
+            this.StockEntities = new List<StockEntity>();
 
         }
 

--- a/InventoryDAL/Products/DAO/ProductEntityMySQLDAO.cs
+++ b/InventoryDAL/Products/DAO/ProductEntityMySQLDAO.cs
@@ -21,7 +21,8 @@ namespace InventoryDAL.Products
         {
             this.dbContext.Database.EnsureCreated();
             Task<List<ProductEntity>> lst = this.Table
-                .Include(pe => pe.ProductTagEntities)
+                //.Include(pe => pe.ProductTagEntities)
+                //.Include(pe => pe.StockEntities)
                 .ToListAsync();
             lst.Wait();
             return lst.Result;

--- a/InventoryDAL/Products/DAO/ProductEntityMySQLDAO.cs
+++ b/InventoryDAL/Products/DAO/ProductEntityMySQLDAO.cs
@@ -21,8 +21,8 @@ namespace InventoryDAL.Products
         {
             this.dbContext.Database.EnsureCreated();
             Task<List<ProductEntity>> lst = this.Table
-                //.Include(pe => pe.ProductTagEntities)
-                //.Include(pe => pe.StockEntities)
+                .Include(pe => pe.ProductTagEntities)
+                .Include(pe => pe.StockEntities)
                 .ToListAsync();
             lst.Wait();
             return lst.Result;

--- a/InventoryDAL/Products/DAO/ProductEntityMySQLDAO.cs
+++ b/InventoryDAL/Products/DAO/ProductEntityMySQLDAO.cs
@@ -3,6 +3,8 @@ using InventoryDAL.Database;
 using InventoryLogic.Facade;
 using Microsoft.EntityFrameworkCore;
 using InventoryDAL.ProductTag;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace InventoryDAL.Products
 {
@@ -13,6 +15,16 @@ namespace InventoryDAL.Products
         public ProductEntityMySQLDAO(MySqlContext context)
             : base(context)
         {
+        }
+
+        public override List<ProductEntity> GetAll()
+        {
+            this.dbContext.Database.EnsureCreated();
+            Task<List<ProductEntity>> lst = this.Table
+                .Include(pe => pe.ProductTagEntities)
+                .ToListAsync();
+            lst.Wait();
+            return lst.Result;
         }
     }
 }

--- a/InventoryDAL/Products/Repository/ProductsRepository.cs
+++ b/InventoryDAL/Products/Repository/ProductsRepository.cs
@@ -52,13 +52,17 @@ namespace InventoryDAL.Products
         private Product BuildProduct(ProductEntity productEntity)
         {
             var productBuilder = builderFactory.CreateProductBuilder(productEntity);
-            return productBuilder.Build();
+            productBuilder.BuildTags();
+            productBuilder.BuildStocks();
+            return productBuilder.GetResult();
         }
 
         private ProductEntity BuildProductEntity(Product product)
         {
             var productEntityBuilder = builderFactory.CreateProductEntityBuilder(product);
-            return productEntityBuilder.Build();
+            productEntityBuilder.BuildProductTagEntities();
+            productEntityBuilder.BuildStockEntities();
+            return productEntityBuilder.GetResult();
         }
     }
 }

--- a/InventoryDAL/Products/Repository/ProductsRepository.cs
+++ b/InventoryDAL/Products/Repository/ProductsRepository.cs
@@ -52,16 +52,16 @@ namespace InventoryDAL.Products
         private Product BuildProduct(ProductEntity productEntity)
         {
             var productBuilder = builderFactory.CreateProductBuilder(productEntity);
-            productBuilder.BuildTags();
-            productBuilder.BuildStocks();
+            //productBuilder.BuildTags();
+            //productBuilder.BuildStocks();
             return productBuilder.GetResult();
         }
 
         private ProductEntity BuildProductEntity(Product product)
         {
             var productEntityBuilder = builderFactory.CreateProductEntityBuilder(product);
-            productEntityBuilder.BuildProductTagEntities();
-            productEntityBuilder.BuildStockEntities();
+            //productEntityBuilder.BuildProductTagEntities();
+            //productEntityBuilder.BuildStockEntities();
             return productEntityBuilder.GetResult();
         }
     }

--- a/InventoryDAL/Products/Repository/ProductsRepository.cs
+++ b/InventoryDAL/Products/Repository/ProductsRepository.cs
@@ -52,16 +52,16 @@ namespace InventoryDAL.Products
         private Product BuildProduct(ProductEntity productEntity)
         {
             var productBuilder = builderFactory.CreateProductBuilder(productEntity);
-            //productBuilder.BuildTags();
-            //productBuilder.BuildStocks();
+            productBuilder.BuildTags();
+            productBuilder.BuildStocks();
             return productBuilder.GetResult();
         }
 
         private ProductEntity BuildProductEntity(Product product)
         {
             var productEntityBuilder = builderFactory.CreateProductEntityBuilder(product);
-            //productEntityBuilder.BuildProductTagEntities();
-            //productEntityBuilder.BuildStockEntities();
+            productEntityBuilder.BuildProductTagEntities();
+            productEntityBuilder.BuildStockEntities();
             return productEntityBuilder.GetResult();
         }
     }

--- a/InventoryDAL/Stocks/Builders/IStockBuilder.cs
+++ b/InventoryDAL/Stocks/Builders/IStockBuilder.cs
@@ -4,6 +4,6 @@ namespace InventoryDAL.Stocks
 {
     public interface IStockBuilder : IStock
     {
-        Stock Build();
+        Stock GetResult();
     }
 }

--- a/InventoryDAL/Stocks/Builders/IStockEntityBuilder.cs
+++ b/InventoryDAL/Stocks/Builders/IStockEntityBuilder.cs
@@ -4,6 +4,6 @@ namespace InventoryDAL.Stocks
 {
     public interface IStockEntityBuilder : IStockEntity
     {
-        StockEntity Build();
+        StockEntity GetResult();
     }
 }

--- a/InventoryDAL/Stocks/Builders/StockBuilder.cs
+++ b/InventoryDAL/Stocks/Builders/StockBuilder.cs
@@ -11,6 +11,8 @@ namespace InventoryDAL.Stocks
     {
         private readonly IDomainFactory domainFactory;
         private readonly IRepositoryFactory repositoryFactory;
+        private readonly StockEntity stockEntity;
+
 
         public int Id { get; set; }
         public int ProductId { get; set; }
@@ -18,26 +20,27 @@ namespace InventoryDAL.Stocks
         public int Amount { get; set; }
         public DateTime Date { get; set; }
 
+
         public StockBuilder(StockEntity stockEntity, IDomainFactory domainFactory, IRepositoryFactory repositoryFactory)
         {
             this.domainFactory = domainFactory;
             this.repositoryFactory = repositoryFactory;
-            
+            this.stockEntity = stockEntity;
+
+
             this.Id = stockEntity.Id;
             this.ProductId = stockEntity.ProductId;
             this.Date = stockEntity.Date;
             this.Amount = stockEntity.Amount;
-            this.Product = GetProduct(stockEntity.ProductId);
         }
 
-        private Product GetProduct(int productId)
+        public void BuildProduct()
         {
-            Product product = repositoryFactory.GetCrudRepository<Product>().Get(productId);
-            if (product == null) throw new InvalidDataException("Product not found. Please first create the product.");
-            return product;
+            Product product = repositoryFactory.GetCrudRepository<Product>().Get(stockEntity.ProductId);
+            this.Product = product ?? throw new InvalidDataException("Product not found. Please first create the product.");
         }
 
-        public Stock Build()
+        public Stock GetResult()
         {
             Stock stock = domainFactory.CreateStock();
             stock.Id = this.Id;

--- a/InventoryDAL/Stocks/Builders/StockEntityBuilder.cs
+++ b/InventoryDAL/Stocks/Builders/StockEntityBuilder.cs
@@ -13,6 +13,8 @@ namespace InventoryDAL.Stocks
     {
         private readonly IEntityFactory entityFactory;
         private readonly IDAOFactory daoFactory;
+        private readonly Stock stock;
+
 
         public int Id { get; set; }
         public int ProductId { get; set; }
@@ -24,22 +26,22 @@ namespace InventoryDAL.Stocks
         {
             this.entityFactory = entityFactory;
             this.daoFactory = daoFactory;
-            
+            this.stock = stock;
+
+
             this.Id = stock.Id;
             this.ProductId = stock.ProductId;
             this.Amount = stock.Amount;
             this.Date = stock.Date;
-            this.ProductEntity = GetProductEntity(stock.ProductId);
         }
 
-        private ProductEntity GetProductEntity(int productId)
+        public void BuildProductEntity()
         {
-            ProductEntity productEntity = daoFactory.ProductEntityDAO.Get(productId);
-            if (productEntity == null) throw new InvalidDataException("Product not found. Please first create the product.");
-            return productEntity;
+            ProductEntity productEntity = daoFactory.ProductEntityDAO.Get(stock.ProductId);
+            this.ProductEntity = productEntity /*?? throw new InvalidDataException("Product not found. Please first create the product.")*/;
         }
 
-        public StockEntity Build()
+        public StockEntity GetResult()
         {
             StockEntity stockEntity = daoFactory.StockEntityDAO.Get(this.Id);
             if (stockEntity == null) stockEntity = entityFactory.CreateStockEntity();

--- a/InventoryDAL/Stocks/Repository/StocksRepository.cs
+++ b/InventoryDAL/Stocks/Repository/StocksRepository.cs
@@ -52,14 +52,14 @@ namespace InventoryDAL.Stocks
         private Stock BuildStock(StockEntity stockEntity)
         {
             var stockBuilder = builderFactory.CreateStockBuilder(stockEntity);
-            stockBuilder.BuildProduct();
+            //stockBuilder.BuildProduct();
             return stockBuilder.GetResult();
         }
 
         private StockEntity BuildStockEntity(Stock stock)
         {
             var stockEntityBuilder = builderFactory.CreateStockEntityBuilder(stock);
-            stockEntityBuilder.BuildProductEntity();
+            //stockEntityBuilder.BuildProductEntity();
             return stockEntityBuilder.GetResult();
         }
     }

--- a/InventoryDAL/Stocks/Repository/StocksRepository.cs
+++ b/InventoryDAL/Stocks/Repository/StocksRepository.cs
@@ -52,13 +52,15 @@ namespace InventoryDAL.Stocks
         private Stock BuildStock(StockEntity stockEntity)
         {
             var stockBuilder = builderFactory.CreateStockBuilder(stockEntity);
-            return stockBuilder.Build();
+            stockBuilder.BuildProduct();
+            return stockBuilder.GetResult();
         }
 
         private StockEntity BuildStockEntity(Stock stock)
         {
             var stockEntityBuilder = builderFactory.CreateStockEntityBuilder(stock);
-            return stockEntityBuilder.Build();
+            stockEntityBuilder.BuildProductEntity();
+            return stockEntityBuilder.GetResult();
         }
     }
 }

--- a/InventoryDAL/Tags/Builders/ITagBuilder.cs
+++ b/InventoryDAL/Tags/Builders/ITagBuilder.cs
@@ -4,6 +4,6 @@ namespace InventoryDAL.Tags
 {
     public interface ITagBuilder : ITag
     {
-        Tag Build();
+        Tag GetResult();
     }
 }

--- a/InventoryDAL/Tags/Builders/ITagEntityBuilder.cs
+++ b/InventoryDAL/Tags/Builders/ITagEntityBuilder.cs
@@ -4,6 +4,6 @@ namespace InventoryDAL.Tags
 {
     public interface ITagEntityBuilder : ITagEntity
     {
-        TagEntity Build();
+        TagEntity GetResult();
     }
 }

--- a/InventoryDAL/Tags/Builders/TagBuilder.cs
+++ b/InventoryDAL/Tags/Builders/TagBuilder.cs
@@ -29,6 +29,7 @@ namespace InventoryDAL.Tags
 
             this.Id = tagEntity.Id;
             this.Name = tagEntity.Name;
+            this.Products = new List<Product>();
         }
 
         public void BuildProducts()

--- a/InventoryDAL/Tags/Builders/TagBuilder.cs
+++ b/InventoryDAL/Tags/Builders/TagBuilder.cs
@@ -14,6 +14,8 @@ namespace InventoryDAL.Tags
     {
         private readonly IDomainFactory domainFactory;
         private readonly IRepositoryFactory repositoryFactory;
+        private readonly TagEntity tagEntity;
+
 
         public int Id { get; set; }
         public string Name { get; set; }
@@ -23,22 +25,23 @@ namespace InventoryDAL.Tags
         {
             this.domainFactory = domainFactory;
             this.repositoryFactory = repositoryFactory;
-            
+            this.tagEntity = tagEntity;
+
             this.Id = tagEntity.Id;
             this.Name = tagEntity.Name;
-            this.Products = GetProducts(tagEntity.ProductTagEntities);
         }
 
-        private List<Product> GetProducts(List<ProductTagEntity> productTagEntities)
+        public void BuildProducts()
         {
-            if (productTagEntities == null) return new List<Product>();
+            List<ProductTagEntity> productTagEntities = tagEntity.ProductTagEntities;
+            if (productTagEntities == null) return;
             List<Product> products = new List<Product>();
             productTagEntities.ForEach(prodTag =>
             {
                 Product product = GetProduct(prodTag);
                 products.Add(product);
             });
-            return products;
+            this.Products = products;
         }
 
         private Product GetProduct(ProductTagEntity prodTag)
@@ -48,7 +51,7 @@ namespace InventoryDAL.Tags
             return product;
         }
 
-        public Tag Build()
+        public Tag GetResult()
         {
             Tag tag = domainFactory.CreateTag();
             tag.Id = this.Id;

--- a/InventoryDAL/Tags/Builders/TagEntityBuilder.cs
+++ b/InventoryDAL/Tags/Builders/TagEntityBuilder.cs
@@ -11,6 +11,8 @@ namespace InventoryDAL.Tags
     {
         private readonly IDAOFactory daoFactory;
         private readonly IEntityFactory entityFactory;
+        private readonly Tag tag;
+
 
         public int Id { get; set; }
         public string Name { get; set; }
@@ -22,22 +24,23 @@ namespace InventoryDAL.Tags
         {
             this.entityFactory = entityFactory;
             this.daoFactory = daoFactory;
+            this.tag = tag;
 
             this.Id = tag.Id;
             this.Name = tag.Name;
-            this.ProductTagEntities = GetProductTagEntities(tag.Id, tag.Products);
         }
 
-        private List<ProductTagEntity> GetProductTagEntities(int tagId, List<Product> products)
+        public void BuildProductTagEntities()
         {
-            if (products == null || products.Count == 0) return new List<ProductTagEntity>();
+            List<Product> products = tag.Products;
+            if (products == null || products.Count == 0) return;
             List<ProductTagEntity> newProductTagEntities = new List<ProductTagEntity>();
             products.ForEach(product =>
             {
-                ProductTagEntity ptEntity = GetProductTagEntity(product.Id, tagId);
+                ProductTagEntity ptEntity = GetProductTagEntity(product.Id, tag.Id);
                 newProductTagEntities.Add(ptEntity);
             });
-            return newProductTagEntities;
+            this.ProductTagEntities = newProductTagEntities;
         }
 
         private ProductTagEntity GetProductTagEntity(int productId, int tagId)
@@ -47,7 +50,7 @@ namespace InventoryDAL.Tags
             return ptEntity;
         }
 
-        public TagEntity Build()
+        public TagEntity GetResult()
         {
             TagEntity tagEntity = daoFactory.TagEntityDAO.Get(this.Id);
             if (tagEntity == null) tagEntity = entityFactory.CreateTagEntity();

--- a/InventoryDAL/Tags/Builders/TagEntityBuilder.cs
+++ b/InventoryDAL/Tags/Builders/TagEntityBuilder.cs
@@ -28,6 +28,7 @@ namespace InventoryDAL.Tags
 
             this.Id = tag.Id;
             this.Name = tag.Name;
+            this.ProductTagEntities = new List<ProductTagEntity>();
         }
 
         public void BuildProductTagEntities()

--- a/InventoryDAL/Tags/Repository/TagsRepository.cs
+++ b/InventoryDAL/Tags/Repository/TagsRepository.cs
@@ -51,13 +51,15 @@ namespace InventoryDAL.Tags
         private Tag BuildTag(TagEntity tagEntity)
         {
             var tagBuilder = builderFactory.CreateTagBuilder(tagEntity);
-            return tagBuilder.Build();
+            tagBuilder.BuildProducts();
+            return tagBuilder.GetResult();
         }
 
         private TagEntity BuildTagEntity(Tag tag)
         {
             var tagEntityBuilder = builderFactory.CreateTagEntityBuilder(tag);
-            return tagEntityBuilder.Build();
+            tagEntityBuilder.BuildProductTagEntities();
+            return tagEntityBuilder.GetResult();
         }
     }
 }

--- a/InventoryDAL/Tags/Repository/TagsRepository.cs
+++ b/InventoryDAL/Tags/Repository/TagsRepository.cs
@@ -51,14 +51,14 @@ namespace InventoryDAL.Tags
         private Tag BuildTag(TagEntity tagEntity)
         {
             var tagBuilder = builderFactory.CreateTagBuilder(tagEntity);
-            tagBuilder.BuildProducts();
+            //tagBuilder.BuildProducts();
             return tagBuilder.GetResult();
         }
 
         private TagEntity BuildTagEntity(Tag tag)
         {
             var tagEntityBuilder = builderFactory.CreateTagEntityBuilder(tag);
-            tagEntityBuilder.BuildProductTagEntities();
+            //tagEntityBuilder.BuildProductTagEntities();
             return tagEntityBuilder.GetResult();
         }
     }

--- a/InventoryLogic/Facade/TagsFacade.cs
+++ b/InventoryLogic/Facade/TagsFacade.cs
@@ -17,7 +17,7 @@ namespace InventoryLogic.Facade
             Product product = repoFactory.GetCrudRepository<Product>().Get(productId);
             if (product == null) throw new ArgumentException("Product not found.");
             Tag tag = repoFactory.GetCrudRepository<Tag>().Get(tagId);
-            if (product == null) throw new ArgumentException("Tag not found.");
+            if (tag == null) throw new ArgumentException("Tag not found.");
 
             if (product.Tags.Contains(tag)) return false;
 

--- a/InventoryLogic/Products/Product.cs
+++ b/InventoryLogic/Products/Product.cs
@@ -61,7 +61,14 @@ namespace InventoryLogic.Products
 
                 toDTO.Stocks.Add(newStockDTO);
             }
-            
+            foreach (Tag tag in Tags)
+            {
+                TagDTO newTagDTO = new TagDTO();
+                tag.ConvertToDTO(newTagDTO);
+
+                toDTO.Tags.Add(newTagDTO);
+            }
+
         }
 
        


### PR DESCRIPTION
Went for the simplest solution: 
- entities still contain navigation properties
- only Product repo maps these to domain models and vice versa (using builders)
- Tag and Stock repo's do not map navigation properties to domain models and vice versa

That fixes the circular reference. If we decide to never use the properties in Tag and Stock we could remove them altogether.